### PR TITLE
initial scala support

### DIFF
--- a/scala/.gitignore
+++ b/scala/.gitignore
@@ -1,0 +1,5 @@
+.idea
+.DS_Store
+target/
+.
+challenges/*.txt

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -1,0 +1,17 @@
+name := "tlp"
+
+version := "1.0"
+
+scalaVersion := "2.11.8"
+
+resolvers += "TDL" at "http://dl.bintray.com/julianghionoiu/maven"
+
+def scalatest = "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+def client = "ro.ghionoiu" % "tdl-client-java" % "0.11.1"
+
+scalacOptions += "-Xexperimental"
+
+libraryDependencies ++= Seq(
+  client,
+  scalatest
+)

--- a/scala/project/build.properties
+++ b/scala/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 0.13.8

--- a/scala/project/plugins.sbt
+++ b/scala/project/plugins.sbt
@@ -1,0 +1,1 @@
+logLevel := Level.Warn

--- a/scala/src/main/resources/logback.xml
+++ b/scala/src/main/resources/logback.xml
@@ -1,0 +1,18 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="competition.client.Client" level="info" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/scala/src/main/scala/befaster/BeFasterApp.scala
+++ b/scala/src/main/scala/befaster/BeFasterApp.scala
@@ -1,0 +1,11 @@
+package befaster
+
+import befaster.runner.ClientRunner
+import befaster.runner.RunnerAction._
+
+object BeFasterApp extends App {
+  ClientRunner.forUserWithEmail("your_email_here")
+    .withServerHostname("hostname_goes_here")
+    .withActionIfNoArgs(connectivityTest)
+    .start(args)
+}

--- a/scala/src/main/scala/befaster/runner/ClientRunner.java
+++ b/scala/src/main/scala/befaster/runner/ClientRunner.java
@@ -1,0 +1,89 @@
+package befaster.runner;
+
+import com.google.common.io.Files;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+
+import tdl.client.Client;
+import tdl.client.ProcessingRules;
+
+import static tdl.client.actions.ClientActions.publish;
+
+public class ClientRunner {
+    private String hostname = "run.befaster.io";
+    private RunnerAction defaultRunnerAction = RunnerAction.connectivityTest;
+    private final String email;
+
+    public static ClientRunner forUserWithEmail(String email) {
+        return new ClientRunner(email);
+    }
+
+    private ClientRunner(String email) {
+        this.email = email;
+    }
+
+    public ClientRunner withServerHostname(String hostname) {
+        this.hostname = hostname;
+        return this;
+    }
+
+    public ClientRunner withActionIfNoArgs(RunnerAction actionIfNoArgs) {
+        defaultRunnerAction = actionIfNoArgs;
+        return this;
+    }
+
+    public void start(String[] args) {
+        RunnerAction runnerAction = extractActionFrom(args).orElse(defaultRunnerAction);
+        System.out.println("Chosen action is: "+runnerAction.name());
+
+        Client client = new Client.Builder()
+                .setHostname(hostname)
+                .setUniqueId(email)
+                .create();
+
+        ProcessingRules processingRules = new ProcessingRules() {{
+            on("display_description").call(p -> displayAndSaveDescription(asString(p[0]), asString(p[1]))).then(publish());
+//            on("sum").call(p -> Sum.sum(asInt(p[0]), asInt(p[1]))).then(runnerAction.getClientAction());
+        }};
+        client.goLiveWith(processingRules);
+    }
+
+    private static Optional<RunnerAction> extractActionFrom(String[] args) {
+        String firstArg = args.length > 0 ? args[0] : null;
+        return Arrays.stream(RunnerAction.values())
+                .map(Enum::name)
+                .filter(s -> s.equalsIgnoreCase(firstArg))
+                .findFirst()
+                .map(RunnerAction::valueOf);
+    }
+
+    //~~~~~~~ Provided implementations ~~~~~~~~~~~~~~
+
+    private static String displayAndSaveDescription(String label, String description) {
+        System.out.println("Starting round: "+label);
+        System.out.println(description);
+
+        //Save description
+        File output = new File("challenges" + File.separator + label + ".txt");
+        try {
+            Files.write(description.getBytes(), output);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        System.out.println("Challenge description saved to file: "+output.getPath()+".");
+
+        return "OK";
+    }
+
+    private static String asString(String s) {
+        return s;
+    }
+
+    private static int asInt(String s) {
+        return Integer.parseInt(s);
+    }
+
+}

--- a/scala/src/main/scala/befaster/runner/RunnerAction.java
+++ b/scala/src/main/scala/befaster/runner/RunnerAction.java
@@ -1,0 +1,20 @@
+package befaster.runner;
+
+import tdl.client.actions.ClientAction;
+import tdl.client.actions.ClientActions;
+
+public enum RunnerAction {
+    getNewRoundDescription(ClientActions.stop()),
+    connectivityTest(ClientActions.stop()),
+    deployToProduction(ClientActions.publish());
+
+    private ClientAction clientAction;
+
+    RunnerAction(ClientAction clientAction) {
+        this.clientAction = clientAction;
+    }
+
+    public ClientAction getClientAction() {
+        return clientAction;
+    }
+}

--- a/scala/src/main/scala/befaster/solutions/Sum.scala
+++ b/scala/src/main/scala/befaster/solutions/Sum.scala
@@ -1,0 +1,5 @@
+package befaster.solutions
+
+object Sum {
+  def sum(x: Int, y: Int): Int = ???
+}

--- a/scala/src/test/scala/befaster/runner/SumTest.scala
+++ b/scala/src/test/scala/befaster/runner/SumTest.scala
@@ -1,0 +1,11 @@
+package befaster.runner
+
+import befaster.solutions.Sum
+import org.scalatest.{FlatSpec, Matchers}
+
+class SumTest extends FlatSpec with Matchers {
+
+  it should "compute sum" in {
+    Sum.sum(1,2) shouldBe 2
+  }
+}


### PR DESCRIPTION
Super basic support for Scala, the ClientRunner is copy-pasted for the time being as it's still WIP upstream from what I gather. I think it might make sense to reuse the same ClientRunner for several JVM languages, so it may be worth extracting into a separate dependency. 

The way to run the methods is still not defined, but it might make sense to follow the same approach across different languages for simplicity sake.